### PR TITLE
Enable CentOS SCL repo on ns7

### DIFF
--- a/nethserver-groups.xml.in
+++ b/nethserver-groups.xml.in
@@ -393,6 +393,7 @@
       <packagereq type="mandatory">traceroute</packagereq>
       <packagereq type="mandatory">deltarpm</packagereq>
       <packagereq type="mandatory">epel-release</packagereq>
+      <packagereq type="mandatory">centos-release-scl</packagereq>
     </packagelist>
   </group>
   


### PR DESCRIPTION
The repository will be available starting from next ISO release.

NethServer/dev#5089