### PR TITLE
Fix File Server group definition

### DIFF
--- a/nethserver-groups.xml.in
+++ b/nethserver-groups.xml.in
@@ -446,7 +446,6 @@
     <uservisible>true</uservisible>
     <packagelist>
       <packagereq type="mandatory">nethserver-samba</packagereq>
-      <packagereq type="mandatory">nethserver-ibays</packagereq>
       <packagereq type="optional">nethserver-samba-audit</packagereq>
     </packagelist>
   </group>


### PR DESCRIPTION
The nethserver-ibays package was merged into nethserver-samba and is no
longer available from the repositories.