### PR TITLE
Fix mail2 requirements

### DIFF
--- a/nethserver-groups.xml.in
+++ b/nethserver-groups.xml.in
@@ -492,6 +492,7 @@
     <uservisible>true</uservisible>
     <packagelist>
       <packagereq type="mandatory">nethserver-webtop5</packagereq>
+      <packagereq type="mandatory">nethserver-mail2-server</packagereq>
     </packagelist>
   </group>
 
@@ -529,6 +530,7 @@
     <uservisible>true</uservisible>
     <packagelist>
       <packagereq type="mandatory">nethserver-roundcubemail</packagereq>
+      <packagereq type="mandatory">nethserver-mail2-server</packagereq>
     </packagelist>
   </group>
 


### PR DESCRIPTION
Both WebTop5 and Roundcube modules must be installed with the new mail2
stack on new installations.

Drawbacks: existing installation with old mail stack shows the modules
as not installed any more.

NethServer/dev#5558