### PR TITLE
Rename web server group

### DIFF
--- a/po/comps.pot
+++ b/po/comps.pot
@@ -110,11 +110,11 @@ msgid "Print management server (CUPS)"
 msgstr ""
 
 #: ../updates-groups.xml.in.h:24 ../arm-updates-groups.xml.in.h:17
-msgid "Web server"
+msgid "Web hosting"
 msgstr ""
 
 #: ../updates-groups.xml.in.h:25 ../arm-updates-groups.xml.in.h:18
-msgid "Configuration tools for Apache web server"
+msgid "Configuration tools for hosting sites on Apache web server"
 msgstr ""
 
 #: ../updates-groups.xml.in.h:26 ../arm-updates-groups.xml.in.h:19

--- a/updates-groups.xml.in
+++ b/updates-groups.xml.in
@@ -560,8 +560,8 @@
 
   <group>
     <id>nethserver-web</id>
-    <_name>Web server</_name>
-    <_description>Configuration tools for Apache web server</_description>
+    <_name>Web hosting</_name>
+    <_description>Configuration tools for hosting sites on Apache web server</_description>
     <default>false</default>
     <uservisible>true</uservisible>
     <packagelist>


### PR DESCRIPTION
Avoid confusion between "Web server" application installed by default
and the module available inside the Software Center.