### PR TITLE
Add nethserver-arm-extra-config to arm iso group

### DIFF
--- a/arm-updates-groups.xml.in
+++ b/arm-updates-groups.xml.in
@@ -168,6 +168,7 @@
       <packagereq type="mandatory">nethserver-inventory</packagereq>
       <packagereq type="mandatory">nethserver-alerts</packagereq>
       <packagereq type="mandatory">nethserver-cockpit</packagereq>
+      <packagereq type="mandatory">nethserver-arm-extra-config</packagereq>     
       <packagereq type="mandatory">lsof</packagereq>
       <packagereq type="mandatory">patch</packagereq>
       <packagereq type="mandatory">rsync</packagereq>


### PR DESCRIPTION
Related to Nethserver/arm-dev#40

**Note:** translations still need to be updated!

Unfortunately updating transifex as described in README did not succeed and exuded the updated "po" too.

```
tx push -s
tx INFO: Pushing resource nethserver.yum_groups_definitions
tx INFO: Pushing source file (po/comps.pot)
tx ERROR: Error received from server: Only maintainers are allowed to update the source file.
tx ERROR: Could not upload source file. You can use --skip to ignore this error and continue the execution.
tx ERROR: Error received from server: Only maintainers are allowed to update the source file.
```