### PR TITLE
Add DAHDI group

### DIFF
--- a/updates-groups.xml.in
+++ b/updates-groups.xml.in
@@ -1000,6 +1000,20 @@
       </packagelist>
   </group>
 
+  <group>
+      <id>dahdi</id>
+      <_name>DAHDI divers and tools</_name>
+      <_description>Support Digium Asterisk Hardware Device Interface</_description>
+      <default>false</default>
+      <uservisible>true</uservisible>
+      <packagelist>
+        <packagereq type="mandatory">kmod-dahdi-linux</packagereq>
+        <packagereq type="mandatory">dahdi-linux</packagereq>
+        <packagereq type="mandatory">dahdi-firmware</packagereq>
+        <packagereq type="mandatory">dahdi-tools</packagereq>
+      </packagelist>
+  </group>
+
 <!-- NETHSERVER GROUPS END -->
 
 <!-- NETHSERVER CATEGORIES START -->
@@ -1036,6 +1050,7 @@
       <groupid>nethserver-nextcloud</groupid>
       <groupid>nethserver-pop3connector</groupid>
       <groupid>nethserver-pbx</groupid>
+      <groupid>dahdi</groupid>
       <groupid>nethserver-subscription</groupid>
       <groupid>nethserver-mattermost</groupid>
       <groupid>nethserver-fail2ban</groupid>

--- a/updates-groups.xml.in
+++ b/updates-groups.xml.in
@@ -1002,7 +1002,7 @@
 
   <group>
       <id>dahdi</id>
-      <_name>DAHDI divers and tools</_name>
+      <_name>DAHDI drivers and tools</_name>
       <_description>Support Digium Asterisk Hardware Device Interface</_description>
       <default>false</default>
       <uservisible>true</uservisible>

--- a/updates-groups.xml.in
+++ b/updates-groups.xml.in
@@ -1011,6 +1011,7 @@
         <packagereq type="mandatory">dahdi-linux</packagereq>
         <packagereq type="mandatory">dahdi-firmware</packagereq>
         <packagereq type="mandatory">dahdi-tools</packagereq>
+        <packagereq type="mandatory">libopenr2</packagereq>
       </packagelist>
   </group>
 


### PR DESCRIPTION
DAHDI is no more a dependency for freepbx package

NethServer/dev#6319

**Note**: remember to push translations to transifex after merge